### PR TITLE
Fix urllib3 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ python-slugify == 1.2.4
 scipy == 0.13.3
 statistics == 1.0.3.5
 statsmodels == 0.6.1
-urllib == 1.21.1
+urllib3 == 1.21.1


### PR DESCRIPTION
Hi,

urllib was a fake package according to http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/, pretending to be https://pypi.python.org/pypi/urllib3/1.22

Worth checking out.

All the best.