### PR TITLE
Rename all re:dash to Redash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 Redash Python Client
 ====================
 
-A client for the re:dash API for stmo (https://sql.telemetry.mozilla.org)
+A client for the Redash API for stmo (https://sql.telemetry.mozilla.org)
 
 =======
 Install

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ setup(
   name = 'redash_client',
   packages = ['redash_client'],
   version = '0.2.2',
-  description = 'A client for the re:dash API for stmo (https://sql.telemetry.mozilla.org)',
+  description = 'A client for the Redash API for stmo (https://sql.telemetry.mozilla.org)',
   author = 'Marina Samuel',
   author_email = 'msamuel@mozilla.com',
   url = 'https://github.com/mozilla/redash_client',


### PR DESCRIPTION
Hi,

I've fixed all `re:dash` to `Redash`.
This changes related to [getredash/redash/issues/1396](https://github.com/getredash/redash/issues/1396).

Can you check this out?

Thank you,