### PR TITLE
README missing on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
+import os
 from setuptools import setup
+
+_here = os.path.dirname(__file__)
+
 setup(
   name = 'redash_client',
   packages = ['redash_client'],
   version = '0.2.4',
   description = 'A client for the Redash API for stmo (https://sql.telemetry.mozilla.org)',
+  long_description= open(os.path.join(_here, 'README.rst')).read(),
   author = 'Marina Samuel',
   author_email = 'msamuel@mozilla.com',
   url = 'https://github.com/mozilla/redash_client',


### PR DESCRIPTION
Fixes #86 

`python setup.py sdist` seems to work. 